### PR TITLE
Add KV.delete and use in server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ All notable changes to this project will be documented in this file.
 - Graph façade with `put_edge` and `out_edges` helpers.
 - MCP CRUD verbs and dependency injection.
 - `make typecheck` target and pytest coverage hook.
+- `KV.delete` convenience method.
 ### Changed
 - Pre-commit now runs pytest with coverage.

--- a/src/llmdb/kv/__init__.py
+++ b/src/llmdb/kv/__init__.py
@@ -37,3 +37,9 @@ class KV:
             cursor = txn.cursor()
             for k, v in cursor:
                 yield unpack(k), decode(v)
+
+    def delete(self, key: Key) -> bool:
+        """Remove ``key`` from the database."""
+        encoded = pack(key)
+        with self.env.begin(write=True) as txn:
+            return bool(txn.delete(encoded))

--- a/src/mcp_server/handlers/kv.py
+++ b/src/mcp_server/handlers/kv.py
@@ -7,7 +7,7 @@ __all__ = ["router"]
 from fastapi import APIRouter, HTTPException, Response, Depends
 
 from llmdb.kv import KV, RawValue
-from llmdb.temporal_key import Key, pack
+from llmdb.temporal_key import Key
 
 router = APIRouter()
 
@@ -34,8 +34,6 @@ async def get_value(key: str, kv: KV = Depends()) -> dict[str, str]:
 
 @router.delete("/kv/{key}")
 async def delete_value(key: str, kv: KV = Depends()) -> Response:
-    encoded = pack(_decode_key(key))
-    with kv.env.begin(write=True) as txn:
-        if not txn.delete(encoded):
-            raise HTTPException(status_code=404)
+    if not kv.delete(_decode_key(key)):
+        raise HTTPException(status_code=404)
     return Response(status_code=204)

--- a/tests/unit/test_kv.py
+++ b/tests/unit/test_kv.py
@@ -9,3 +9,12 @@ def test_put_get(tmp_path):
     val = db.get(key)
     assert isinstance(val, RawValue)
     assert val.payload == b"bar"
+
+
+def test_delete(tmp_path):
+    db = KV(str(tmp_path))
+    key = (0, b"foo", 0, 0)
+    db.put(key, RawValue(payload=b"bar"))
+    assert db.delete(key) is True
+    assert db.get(key) is None
+    assert db.delete(key) is False


### PR DESCRIPTION
## Summary
- support key deletion in KV API
- use KV.delete from MCP handler
- test delete logic
- document the new method in CHANGELOG

## Testing
- `ruff check --fix .`
- `black src/llmdb/kv/__init__.py src/mcp_server/handlers/kv.py tests/unit/test_kv.py`
- `mypy src/llmdb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687abb9d0ce8832095e707d48e7b0997